### PR TITLE
Added quotes around scenario; added concurrent copies to consle output

### DIFF
--- a/src/NBomber/DomainServices/Reporting/TxtReport.fs
+++ b/src/NBomber/DomainServices/Reporting/TxtReport.fs
@@ -12,9 +12,10 @@ let print (stats: GlobalStats) =
     |> String.concat(Environment.NewLine)
 
 let private printScenarioHeader (scnStats: ScenarioStats) =
-    String.Format("Scenario: {0}, execution time: {1}",
+    String.Format("Scenario: '{0}', execution time: {1}, concurrent copies: {2}",
                   scnStats.ScenarioName,
-                  scnStats.Duration.ToString())
+                  scnStats.Duration.ToString(),
+                  scnStats.ConcurrentCopies)
 
 let private printStepsTable (steps: StepStats[]) =    
     let stepTable = ConsoleTable("step name", "request_count", "OK", "failed", "RPS", "min", "mean", "max", "50%", "75%", "95%", "StdDev")

--- a/src/NBomber/DomainServices/Reporting/TxtReport.fs
+++ b/src/NBomber/DomainServices/Reporting/TxtReport.fs
@@ -12,7 +12,7 @@ let print (stats: GlobalStats) =
     |> String.concat(Environment.NewLine)
 
 let private printScenarioHeader (scnStats: ScenarioStats) =
-    String.Format("Scenario: '{0}', execution time: {1}, concurrent copies: {2}",
+    String.Format("Scenario: '{0}', execution time: {1}, concurrent users: {2}",
                   scnStats.ScenarioName,
                   scnStats.Duration.ToString(),
                   scnStats.ConcurrentCopies)


### PR DESCRIPTION
Changed from:
[13:07:53 INF] Scenario: test github, execution time: 00:00:20

to:
[13:07:53 INF] Scenario: 'test github', execution time: 00:00:20, concurrent copies: 300