### PR TITLE
adding with 'output file name' to be able to specify report file name

### DIFF
--- a/examples/CSharp/CSharp.Examples/Program.cs
+++ b/examples/CSharp/CSharp.Examples/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NBomber.CSharp;
 using CSharp.Examples.Scenarios;
+using NBomber.Contracts;
 
 namespace CSharp.Examples
 {

--- a/examples/CSharp/CSharp.Examples/Program.cs
+++ b/examples/CSharp/CSharp.Examples/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using NBomber.Contracts;
 using NBomber.CSharp;
 using CSharp.Examples.Scenarios;
-using NBomber.Contracts;
 
 namespace CSharp.Examples
 {
@@ -19,8 +19,8 @@ namespace CSharp.Examples
 
             NBomberRunner.RegisterScenarios(scenario)
                          //.LoadConfig("config.json")
-                         //.WithOutputFilename("custom_report_name")
-                         //.WithOutputFileTypes(FileType.Txt, FileType.Html)
+                         //.WithReportFilename("custom_report_name")
+                         //.WithReportFormats(FileType.Txt, FileType.Html)
                          .RunInConsole();
         }
     }

--- a/examples/CSharp/CSharp.Examples/Program.cs
+++ b/examples/CSharp/CSharp.Examples/Program.cs
@@ -20,7 +20,7 @@ namespace CSharp.Examples
             NBomberRunner.RegisterScenarios(scenario)
                          //.LoadConfig("config.json")
                          //.WithOutputFilename("custom_report_name")
-                         //.WithOutputFileTypes(new [] { FileType.Txt, FileType.Html })
+                         //.WithOutputFileTypes(FileType.Txt, FileType.Html)
                          .RunInConsole();
         }
     }

--- a/examples/CSharp/CSharp.Examples/Program.cs
+++ b/examples/CSharp/CSharp.Examples/Program.cs
@@ -19,8 +19,8 @@ namespace CSharp.Examples
 
             NBomberRunner.RegisterScenarios(scenario)
                          //.LoadConfig("config.json")
-                         //.WithReportFilename("custom_report_name")
-                         //.WithReportFormats(FileType.Txt, FileType.Html)
+                         //.WithReportFileName("custom_report_name")
+                         //.WithReportFormats(ReportFormat.Txt, ReportFormat.Html, ReportFormat.Csv)
                          .RunInConsole();
         }
     }

--- a/examples/CSharp/CSharp.Examples/Program.cs
+++ b/examples/CSharp/CSharp.Examples/Program.cs
@@ -18,6 +18,8 @@ namespace CSharp.Examples
 
             NBomberRunner.RegisterScenarios(scenario)
                          //.LoadConfig("config.json")
+                         //.WithOutputFilename("custom_report_name")
+                         //.WithOutputFileTypes(new [] { FileType.Txt, FileType.Html })
                          .RunInConsole();
         }
     }

--- a/examples/FSharp/FSharp.Examples/Program.fs
+++ b/examples/FSharp/FSharp.Examples/Program.fs
@@ -13,7 +13,7 @@ let main argv =
     // |> NBomberRunner.registerScenarios
     // |> NBomberRunner.loadConfig "config.json"
     // |> NBomberRunner.withOutputFilename "custom_report_name"
-    // |> NBomberRunner.withOutputFileTypes [| FileType.Csv |]
+    // |> NBomberRunner.withOutputFileTypes [FileType.Csv]
     |> NBomberRunner.runInConsole
 
     0

--- a/examples/FSharp/FSharp.Examples/Program.fs
+++ b/examples/FSharp/FSharp.Examples/Program.fs
@@ -13,7 +13,7 @@ let main argv =
     // |> NBomberRunner.registerScenarios
     // |> NBomberRunner.loadConfig "config.json"
     // |> NBomberRunner.withReportFileName "custom_report_name"
-    // |> NBomberRunner.withReportFormats [FileType.Csv]
+    // |> NBomberRunner.withReportFormats [ReportFormat.Txt; ReportFormat.Html; ReportFormat.Csv]
     |> NBomberRunner.runInConsole
 
     0

--- a/examples/FSharp/FSharp.Examples/Program.fs
+++ b/examples/FSharp/FSharp.Examples/Program.fs
@@ -11,6 +11,7 @@ let main argv =
     |> NBomberRunner.registerScenario
     // |> NBomberRunner.registerScenarios
     // |> NBomberRunner.loadConfig "config.json"
+    // |> NBomberRunner.withOutputFilename "custom_report_name"
     |> NBomberRunner.runInConsole
 
     0

--- a/examples/FSharp/FSharp.Examples/Program.fs
+++ b/examples/FSharp/FSharp.Examples/Program.fs
@@ -12,8 +12,8 @@ let main argv =
     |> NBomberRunner.registerScenario
     // |> NBomberRunner.registerScenarios
     // |> NBomberRunner.loadConfig "config.json"
-    // |> NBomberRunner.withOutputFilename "custom_report_name"
-    // |> NBomberRunner.withOutputFileTypes [FileType.Csv]
+    // |> NBomberRunner.withReportFileName "custom_report_name"
+    // |> NBomberRunner.withReportFormats [FileType.Csv]
     |> NBomberRunner.runInConsole
 
     0

--- a/examples/FSharp/FSharp.Examples/Program.fs
+++ b/examples/FSharp/FSharp.Examples/Program.fs
@@ -1,5 +1,6 @@
 ﻿open System
 open NBomber.FSharp
+open NBomber.Contracts
 
 [<EntryPoint>]
 let main argv =
@@ -12,6 +13,7 @@ let main argv =
     // |> NBomberRunner.registerScenarios
     // |> NBomberRunner.loadConfig "config.json"
     // |> NBomberRunner.withOutputFilename "custom_report_name"
+    // |> NBomberRunner.withOutputFileTypes [| FileType.Csv |]
     |> NBomberRunner.runInConsole
 
     0

--- a/src/NBomber/Api/CSharp.fs
+++ b/src/NBomber/Api/CSharp.fs
@@ -28,6 +28,8 @@ type Assertion =
         if isNull label then Assertion.forStep(stepName, assertion.Invoke)
         else Assertion.forStep(stepName, assertion.Invoke, label)
 
+type FileType = Txt | Html | Csv
+
 [<Extension>]
 type ScenarioBuilder =
 
@@ -63,6 +65,24 @@ type NBomberRunner =
     [<Extension>]
     static member LoadConfig(context: NBomberRunnerContext, path: string) =
         context |> FSharp.NBomberRunner.loadConfig(path)
+
+    [<Extension>]
+    static member WithOutputFilename(context: NBomberRunnerContext, outputFilename: string) =
+        context |> FSharp.NBomberRunner.withOutputFilename(outputFilename)
+
+    [<Extension>]
+    static member WithOutputFileTypes(context: NBomberRunnerContext, outputFileTypes: FileType[]) =
+        let mutable fileTypes : FSharp.FileType list = []
+
+        let isPrintingTxt = outputFileTypes |> Array.exists(fun x -> x = FileType.Txt)
+        let isPrintingHtml = outputFileTypes |> Array.exists(fun x -> x = FileType.Html)
+        let isPrintingCsv = outputFileTypes |> Array.exists(fun x -> x = FileType.Csv)
+
+        if(isPrintingTxt) then fileTypes <- FSharp.FileType.Txt :: fileTypes
+        if(isPrintingHtml) then fileTypes <- FSharp.FileType.Html :: fileTypes
+        if(isPrintingCsv) then fileTypes <- FSharp.FileType.Csv :: fileTypes
+
+        context |> FSharp.NBomberRunner.withOutputFileTypes((fileTypes |> List.toArray))   
 
     [<Extension>]
     static member Run(context: NBomberRunnerContext) =

--- a/src/NBomber/Api/CSharp.fs
+++ b/src/NBomber/Api/CSharp.fs
@@ -28,8 +28,6 @@ type Assertion =
         if isNull label then Assertion.forStep(stepName, assertion.Invoke)
         else Assertion.forStep(stepName, assertion.Invoke, label)
 
-type FileType = Txt | Html | Csv
-
 [<Extension>]
 type ScenarioBuilder =
 
@@ -72,17 +70,7 @@ type NBomberRunner =
 
     [<Extension>]
     static member WithOutputFileTypes(context: NBomberRunnerContext, outputFileTypes: FileType[]) =
-        let mutable fileTypes : FSharp.FileType list = []
-
-        let isPrintingTxt = outputFileTypes |> Array.exists(fun x -> x = FileType.Txt)
-        let isPrintingHtml = outputFileTypes |> Array.exists(fun x -> x = FileType.Html)
-        let isPrintingCsv = outputFileTypes |> Array.exists(fun x -> x = FileType.Csv)
-
-        if(isPrintingTxt) then fileTypes <- FSharp.FileType.Txt :: fileTypes
-        if(isPrintingHtml) then fileTypes <- FSharp.FileType.Html :: fileTypes
-        if(isPrintingCsv) then fileTypes <- FSharp.FileType.Csv :: fileTypes
-
-        context |> FSharp.NBomberRunner.withOutputFileTypes((fileTypes |> List.toArray))   
+        context |> FSharp.NBomberRunner.withOutputFileTypes(outputFileTypes)   
 
     [<Extension>]
     static member Run(context: NBomberRunnerContext) =

--- a/src/NBomber/Api/CSharp.fs
+++ b/src/NBomber/Api/CSharp.fs
@@ -69,8 +69,9 @@ type NBomberRunner =
         context |> FSharp.NBomberRunner.withOutputFilename(outputFilename)
 
     [<Extension>]
-    static member WithOutputFileTypes(context: NBomberRunnerContext, outputFileTypes: FileType[]) =
-        context |> FSharp.NBomberRunner.withOutputFileTypes(outputFileTypes)   
+    static member WithOutputFileTypes(context: NBomberRunnerContext, [<System.ParamArray>]outputFileTypes: FileType[]) =
+        let fileTypes = outputFileTypes |> Seq.toList
+        context |> FSharp.NBomberRunner.withOutputFileTypes(fileTypes)   
 
     [<Extension>]
     static member Run(context: NBomberRunnerContext) =

--- a/src/NBomber/Api/CSharp.fs
+++ b/src/NBomber/Api/CSharp.fs
@@ -65,13 +65,13 @@ type NBomberRunner =
         context |> FSharp.NBomberRunner.loadConfig(path)
 
     [<Extension>]
-    static member WithOutputFilename(context: NBomberRunnerContext, outputFilename: string) =
-        context |> FSharp.NBomberRunner.withOutputFilename(outputFilename)
+    static member WithReportFileName(context: NBomberRunnerContext, reportFileName: string) =
+        context |> FSharp.NBomberRunner.withReportFileName(reportFileName)
 
     [<Extension>]
-    static member WithOutputFileTypes(context: NBomberRunnerContext, [<System.ParamArray>]outputFileTypes: FileType[]) =
-        let fileTypes = outputFileTypes |> Seq.toList
-        context |> FSharp.NBomberRunner.withOutputFileTypes(fileTypes)   
+    static member WithReportFormats(context: NBomberRunnerContext, [<System.ParamArray>]reportFormats: ReportFormat[]) =
+        let formats = reportFormats |> Seq.toList
+        context |> FSharp.NBomberRunner.withReportFormats(formats)   
 
     [<Extension>]
     static member Run(context: NBomberRunnerContext) =

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -117,10 +117,13 @@ module NBomberRunner =
     open NBomber.Infra        
 
     let registerScenario (scenario: Contracts.Scenario) = 
-        { Scenarios = [|scenario|]; NBomberConfig = None }
+        { Scenarios = [|scenario|]; NBomberConfig = None; OutputFilename = None }
 
     let registerScenarios (scenarios: Contracts.Scenario list) = 
-        { Scenarios = Seq.toArray(scenarios); NBomberConfig = None }
+        { Scenarios = Seq.toArray(scenarios); NBomberConfig = None; OutputFilename = None }
+
+    let withOutputFilename (outputFilename: string) (context: NBomberRunnerContext) =
+        { context with OutputFilename = Some outputFilename }    
 
     let loadConfig (path: string) (context: NBomberRunnerContext) =
         let config = path |> File.ReadAllText |> NBomberConfig.parse

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -119,21 +119,21 @@ module NBomberRunner =
     let registerScenario (scenario: Contracts.Scenario) = 
         { Scenarios = [|scenario|];
             NBomberConfig = None;
-            OutputFilename = None;
-            OutputFileTypes = [|FileType.Txt; FileType.Html; FileType.Csv|] }
+            ReportFileName = None;
+            ReportFormats = [|ReportFormat.Txt; ReportFormat.Html; ReportFormat.Csv|] }
 
     let registerScenarios (scenarios: Contracts.Scenario list) = 
         { Scenarios = Seq.toArray(scenarios);
             NBomberConfig = None;
-            OutputFilename = None;
-            OutputFileTypes = [|FileType.Txt; FileType.Html; FileType.Csv|] }
+            ReportFileName = None;
+            ReportFormats = [|ReportFormat.Txt; ReportFormat.Html; ReportFormat.Csv|] }
 
-    let withOutputFilename (outputFilename: string) (context: NBomberRunnerContext) =
-        { context with OutputFilename = Some outputFilename }
+    let withReportFileName (reportFileName: string) (context: NBomberRunnerContext) =
+        { context with ReportFileName = Some reportFileName }
 
-    let withOutputFileTypes (outputFileTypes: FileType list) (context: NBomberRunnerContext) =
-        let fileTypes = outputFileTypes |> Seq.toArray
-        { context with OutputFileTypes = fileTypes }    
+    let withReportFormats (reportFormats: ReportFormat list) (context: NBomberRunnerContext) =
+        let formats = reportFormats |> Seq.toArray
+        { context with ReportFormats = formats }    
 
     let loadConfig (path: string) (context: NBomberRunnerContext) =
         let config = path |> File.ReadAllText |> NBomberConfig.parse

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -131,8 +131,9 @@ module NBomberRunner =
     let withOutputFilename (outputFilename: string) (context: NBomberRunnerContext) =
         { context with OutputFilename = Some outputFilename }
 
-    let withOutputFileTypes (outputFileTypes: FileType[]) (context: NBomberRunnerContext) =
-        { context with OutputFileTypes = outputFileTypes }    
+    let withOutputFileTypes (outputFileTypes: FileType list) (context: NBomberRunnerContext) =
+        let fileTypes = outputFileTypes |> Seq.toArray
+        { context with OutputFileTypes = fileTypes }    
 
     let loadConfig (path: string) (context: NBomberRunnerContext) =
         let config = path |> File.ReadAllText |> NBomberConfig.parse

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -78,6 +78,8 @@ type Assertion =
     static member forStep (stepName, assertion: AssertStats -> bool, ?label: string) =         
         Domain.DomainTypes.Assertion.Step({ StepName = stepName; ScenarioName = ""; AssertFunc = assertion; Label = label }) :> IAssertion
 
+type FileType = Txt | Html | Csv
+
 module Scenario =        
     
     let create (name: string, steps: IStep list): Contracts.Scenario =
@@ -117,13 +119,22 @@ module NBomberRunner =
     open NBomber.Infra        
 
     let registerScenario (scenario: Contracts.Scenario) = 
-        { Scenarios = [|scenario|]; NBomberConfig = None; OutputFilename = None }
+        { Scenarios = [|scenario|];
+            NBomberConfig = None;
+            OutputFilename = None;
+            OutputFileTypes = [|"Txt"; "Html"; "Csv"|] }
 
     let registerScenarios (scenarios: Contracts.Scenario list) = 
-        { Scenarios = Seq.toArray(scenarios); NBomberConfig = None; OutputFilename = None }
+        { Scenarios = Seq.toArray(scenarios);
+            NBomberConfig = None;
+            OutputFilename = None;
+            OutputFileTypes = [|"Txt"; "Html"; "Csv"|] }
 
     let withOutputFilename (outputFilename: string) (context: NBomberRunnerContext) =
-        { context with OutputFilename = Some outputFilename }    
+        { context with OutputFilename = Some outputFilename }
+
+    let withOutputFileTypes (outputFileTypes: FileType[]) (context: NBomberRunnerContext) =
+        { context with OutputFileTypes = (outputFileTypes |> Array.map(fun x -> x.ToString())) }    
 
     let loadConfig (path: string) (context: NBomberRunnerContext) =
         let config = path |> File.ReadAllText |> NBomberConfig.parse

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -78,8 +78,6 @@ type Assertion =
     static member forStep (stepName, assertion: AssertStats -> bool, ?label: string) =         
         Domain.DomainTypes.Assertion.Step({ StepName = stepName; ScenarioName = ""; AssertFunc = assertion; Label = label }) :> IAssertion
 
-type FileType = Txt | Html | Csv
-
 module Scenario =        
     
     let create (name: string, steps: IStep list): Contracts.Scenario =
@@ -122,19 +120,19 @@ module NBomberRunner =
         { Scenarios = [|scenario|];
             NBomberConfig = None;
             OutputFilename = None;
-            OutputFileTypes = [|"Txt"; "Html"; "Csv"|] }
+            OutputFileTypes = [|FileType.Txt; FileType.Html; FileType.Csv|] }
 
     let registerScenarios (scenarios: Contracts.Scenario list) = 
         { Scenarios = Seq.toArray(scenarios);
             NBomberConfig = None;
             OutputFilename = None;
-            OutputFileTypes = [|"Txt"; "Html"; "Csv"|] }
+            OutputFileTypes = [|FileType.Txt; FileType.Html; FileType.Csv|] }
 
     let withOutputFilename (outputFilename: string) (context: NBomberRunnerContext) =
         { context with OutputFilename = Some outputFilename }
 
     let withOutputFileTypes (outputFileTypes: FileType[]) (context: NBomberRunnerContext) =
-        { context with OutputFileTypes = (outputFileTypes |> Array.map(fun x -> x.ToString())) }    
+        { context with OutputFileTypes = outputFileTypes }    
 
     let loadConfig (path: string) (context: NBomberRunnerContext) =
         let config = path |> File.ReadAllText |> NBomberConfig.parse

--- a/src/NBomber/Contracts.fs
+++ b/src/NBomber/Contracts.fs
@@ -58,5 +58,6 @@ type Response with
 
 type NBomberRunnerContext = {
     Scenarios: Scenario[]
-    NBomberConfig: NBomberConfig option    
+    NBomberConfig: NBomberConfig option  
+    OutputFilename: String option 
 }

--- a/src/NBomber/Contracts.fs
+++ b/src/NBomber/Contracts.fs
@@ -56,9 +56,11 @@ type Response with
     static member Ok([<Optional;DefaultParameterValue(null:obj)>]payload: obj) = { IsOk = true; Payload = payload }
     static member Fail(error: string) = { IsOk = false; Payload = error }
 
+type FileType = Txt | Html | Csv
+
 type NBomberRunnerContext = {
     Scenarios: Scenario[]
     NBomberConfig: NBomberConfig option  
     OutputFilename: string option
-    OutputFileTypes: string []
+    OutputFileTypes: FileType []
 }

--- a/src/NBomber/Contracts.fs
+++ b/src/NBomber/Contracts.fs
@@ -59,5 +59,6 @@ type Response with
 type NBomberRunnerContext = {
     Scenarios: Scenario[]
     NBomberConfig: NBomberConfig option  
-    OutputFilename: String option 
+    OutputFilename: string option
+    OutputFileTypes: string []
 }

--- a/src/NBomber/Contracts.fs
+++ b/src/NBomber/Contracts.fs
@@ -56,11 +56,11 @@ type Response with
     static member Ok([<Optional;DefaultParameterValue(null:obj)>]payload: obj) = { IsOk = true; Payload = payload }
     static member Fail(error: string) = { IsOk = false; Payload = error }
 
-type FileType = Txt | Html | Csv
+type ReportFormat = Txt | Html | Csv
 
 type NBomberRunnerContext = {
     Scenarios: Scenario[]
     NBomberConfig: NBomberConfig option  
-    OutputFilename: string option
-    OutputFileTypes: FileType []
+    ReportFileName: string option
+    ReportFormats: ReportFormat []
 }

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -144,7 +144,7 @@ let run (dep: Dependency, context: NBomberRunnerContext) =
             let allAsserts = scnRunners |> Array.collect(fun x -> x.Scenario.Assertions)
             let assertResults = Assertion.apply(globalStats, allAsserts)
             Report.build(dep, globalStats, assertResults)
-            |> Report.save(dep, "./", context.OutputFilename)
+            |> Report.save(dep, "./", context.OutputFilename, context.OutputFileTypes)
                         
             cleanScenarios(scnRunners)
 

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -144,7 +144,7 @@ let run (dep: Dependency, context: NBomberRunnerContext) =
             let allAsserts = scnRunners |> Array.collect(fun x -> x.Scenario.Assertions)
             let assertResults = Assertion.apply(globalStats, allAsserts)
             Report.build(dep, globalStats, assertResults)
-            |> Report.save(dep, "./", context.OutputFilename, context.OutputFileTypes)
+            |> Report.save(dep, "./", context.ReportFileName, context.ReportFormats)
                         
             cleanScenarios(scnRunners)
 

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -144,7 +144,7 @@ let run (dep: Dependency, context: NBomberRunnerContext) =
             let allAsserts = scnRunners |> Array.collect(fun x -> x.Scenario.Assertions)
             let assertResults = Assertion.apply(globalStats, allAsserts)
             Report.build(dep, globalStats, assertResults)
-            |> Report.save(dep, "./")
+            |> Report.save(dep, "./", context.OutputFilename)
                         
             cleanScenarios(scnRunners)
 

--- a/src/NBomber/DomainServices/Reporting/Report.fs
+++ b/src/NBomber/DomainServices/Reporting/Report.fs
@@ -24,18 +24,18 @@ let build (dep: Dependency, stats: GlobalStats,
       HtmlReport = HtmlReport.print(dep, stats)
       CsvReport = CsvReport.print(stats) }
 
-let save (dep: Dependency, outPutDir: string, outputFilename: string option, outputFiletypes: FileType[]) (report: ReportResult) =
+let save (dep: Dependency, outPutDir: string, reportFileName: string option, reportFormats: ReportFormat[]) (report: ReportResult) =
     try
         let reportsDir = Path.Combine(outPutDir, "reports")
         Directory.CreateDirectory(reportsDir) |> ignore
         ResourceManager.saveAssets(reportsDir)
         
-        let fileName = outputFilename |> Option.defaultValue ("report_" + dep.SessionId)
+        let fileName = reportFileName |> Option.defaultValue ("report_" + dep.SessionId)
         let filePath = reportsDir + "/" + fileName
         
-        let isPrintingTxt = outputFiletypes |> Array.exists(fun x -> x = FileType.Txt)
-        let isPrintingHtml = outputFiletypes |> Array.exists(fun x -> x = FileType.Html)
-        let isPrintingCsv = outputFiletypes |> Array.exists(fun x -> x = FileType.Csv)
+        let isPrintingTxt = reportFormats |> Array.exists(fun x -> x = ReportFormat.Txt)
+        let isPrintingHtml = reportFormats |> Array.exists(fun x -> x = ReportFormat.Html)
+        let isPrintingCsv = reportFormats |> Array.exists(fun x -> x = ReportFormat.Csv)
 
         if(isPrintingTxt) then File.WriteAllText(filePath + ".txt", report.TxtReport)
         if(isPrintingHtml) then File.WriteAllText(filePath + ".Html", report.HtmlReport)

--- a/src/NBomber/DomainServices/Reporting/Report.fs
+++ b/src/NBomber/DomainServices/Reporting/Report.fs
@@ -10,6 +10,7 @@ open NBomber.Domain.StatisticsTypes
 open NBomber.Domain.Errors
 open NBomber.Infra
 open NBomber.Infra.Dependency
+open NBomber.Contracts
 
 type ReportResult = {
     TxtReport: string
@@ -23,7 +24,7 @@ let build (dep: Dependency, stats: GlobalStats,
       HtmlReport = HtmlReport.print(dep, stats)
       CsvReport = CsvReport.print(stats) }
 
-let save (dep: Dependency, outPutDir: string, outputFilename: string option, outputFiletypes: string[]) (report: ReportResult) =
+let save (dep: Dependency, outPutDir: string, outputFilename: string option, outputFiletypes: FileType[]) (report: ReportResult) =
     try
         let reportsDir = Path.Combine(outPutDir, "reports")
         Directory.CreateDirectory(reportsDir) |> ignore
@@ -32,9 +33,9 @@ let save (dep: Dependency, outPutDir: string, outputFilename: string option, out
         let fileName = outputFilename |> Option.defaultValue ("report_" + dep.SessionId)
         let filePath = reportsDir + "/" + fileName
         
-        let isPrintingTxt = outputFiletypes |> Array.exists(fun x -> x = "Txt")
-        let isPrintingHtml = outputFiletypes |> Array.exists(fun x -> x = "Html")
-        let isPrintingCsv = outputFiletypes |> Array.exists(fun x -> x = "Csv")
+        let isPrintingTxt = outputFiletypes |> Array.exists(fun x -> x = FileType.Txt)
+        let isPrintingHtml = outputFiletypes |> Array.exists(fun x -> x = FileType.Html)
+        let isPrintingCsv = outputFiletypes |> Array.exists(fun x -> x = FileType.Csv)
 
         if(isPrintingTxt) then File.WriteAllText(filePath + ".txt", report.TxtReport)
         if(isPrintingHtml) then File.WriteAllText(filePath + ".Html", report.HtmlReport)

--- a/src/NBomber/DomainServices/Reporting/Report.fs
+++ b/src/NBomber/DomainServices/Reporting/Report.fs
@@ -23,7 +23,7 @@ let build (dep: Dependency, stats: GlobalStats,
       HtmlReport = HtmlReport.print(dep, stats)
       CsvReport = CsvReport.print(stats) }
 
-let save (dep: Dependency, outPutDir: string, outputFilename: string option) (report: ReportResult) =
+let save (dep: Dependency, outPutDir: string, outputFilename: string option, outputFiletypes: string[]) (report: ReportResult) =
     try
         let reportsDir = Path.Combine(outPutDir, "reports")
         Directory.CreateDirectory(reportsDir) |> ignore
@@ -32,9 +32,14 @@ let save (dep: Dependency, outPutDir: string, outputFilename: string option) (re
         let fileName = outputFilename |> Option.defaultValue ("report_" + dep.SessionId)
         let filePath = reportsDir + "/" + fileName
         
-        File.WriteAllText(filePath + ".txt", report.TxtReport)
-        File.WriteAllText(filePath + ".html", report.HtmlReport)
-        File.WriteAllText(filePath + ".csv", report.CsvReport)    
+        let isPrintingTxt = outputFiletypes |> Array.exists(fun x -> x = "Txt")
+        let isPrintingHtml = outputFiletypes |> Array.exists(fun x -> x = "Html")
+        let isPrintingCsv = outputFiletypes |> Array.exists(fun x -> x = "Csv")
+
+        if(isPrintingTxt) then File.WriteAllText(filePath + ".txt", report.TxtReport)
+        if(isPrintingHtml) then File.WriteAllText(filePath + ".Html", report.HtmlReport)
+        if(isPrintingCsv) then File.WriteAllText(filePath + ".csv", report.CsvReport)
+ 
         Log.Information("reports saved in folder: '{0}', {1}", DirectoryInfo(reportsDir).FullName, Environment.NewLine)
         Log.Information(report.TxtReport)
     with

--- a/src/NBomber/DomainServices/Reporting/Report.fs
+++ b/src/NBomber/DomainServices/Reporting/Report.fs
@@ -23,14 +23,15 @@ let build (dep: Dependency, stats: GlobalStats,
       HtmlReport = HtmlReport.print(dep, stats)
       CsvReport = CsvReport.print(stats) }
 
-let save (dep: Dependency, outPutDir: string) (report: ReportResult) =
+let save (dep: Dependency, outPutDir: string, outputFilename: string option) (report: ReportResult) =
     try
         let reportsDir = Path.Combine(outPutDir, "reports")
         Directory.CreateDirectory(reportsDir) |> ignore
         ResourceManager.saveAssets(reportsDir)
-
-        let filePath = reportsDir + "/report_" + dep.SessionId
-
+        
+        let fileName = outputFilename |> Option.defaultValue ("report_" + dep.SessionId)
+        let filePath = reportsDir + "/" + fileName
+        
         File.WriteAllText(filePath + ".txt", report.TxtReport)
         File.WriteAllText(filePath + ".html", report.HtmlReport)
         File.WriteAllText(filePath + ".csv", report.CsvReport)    

--- a/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
+++ b/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
@@ -14,7 +14,7 @@ let buildConfig (scenarioName: string, settings: ScenarioSetting[], targetScenar
     let globalSettings = { ScenariosSettings = settings; TargetScenarios = targetScenarios }
     let config = { NBomberConfig.GlobalSettings = Some globalSettings }
     
-    { Scenarios = [|scenario|]; NBomberConfig = Some config }
+    { Scenarios = [|scenario|]; NBomberConfig = Some config; OutputFilename = None }
 
 let buildSettings (scenarioName: string, duration: TimeSpan, concurrentCopies: int) =
     { ScenarioName = scenarioName; Duration = duration; ConcurrentCopies = concurrentCopies }

--- a/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
+++ b/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
@@ -14,7 +14,7 @@ let buildConfig (scenarioName: string, settings: ScenarioSetting[], targetScenar
     let globalSettings = { ScenariosSettings = settings; TargetScenarios = targetScenarios }
     let config = { NBomberConfig.GlobalSettings = Some globalSettings }
     
-    { Scenarios = [|scenario|]; NBomberConfig = Some config; OutputFilename = None }
+    { Scenarios = [|scenario|]; NBomberConfig = Some config; OutputFilename = None; OutputFileTypes = [||] }
 
 let buildSettings (scenarioName: string, duration: TimeSpan, concurrentCopies: int) =
     { ScenarioName = scenarioName; Duration = duration; ConcurrentCopies = concurrentCopies }

--- a/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
+++ b/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
@@ -14,7 +14,7 @@ let buildConfig (scenarioName: string, settings: ScenarioSetting[], targetScenar
     let globalSettings = { ScenariosSettings = settings; TargetScenarios = targetScenarios }
     let config = { NBomberConfig.GlobalSettings = Some globalSettings }
     
-    { Scenarios = [|scenario|]; NBomberConfig = Some config; OutputFilename = None; OutputFileTypes = [||] }
+    { Scenarios = [|scenario|]; NBomberConfig = Some config; ReportFileName = None; ReportFormats = [||] }
 
 let buildSettings (scenarioName: string, duration: TimeSpan, concurrentCopies: int) =
     { ScenarioName = scenarioName; Duration = duration; ConcurrentCopies = concurrentCopies }


### PR DESCRIPTION
- added `OutputFilename : string option` to `NBomberRunnerContext` class

- method for adding that filename:
```
    let withOutputFilename (outputFilename: string) (context: NBomberRunnerContext) =
        { context with OutputFilename = Some outputFilename } 
```

- API: ` 
....
|> NBomberRunner.withOutputFilename "custom_report_name"
....`