### PR TITLE
removing option from report file name; adding more output to the cons…

### DIFF
--- a/src/NBomber/Configuration.fs
+++ b/src/NBomber/Configuration.fs
@@ -12,7 +12,7 @@ type ScenarioSetting = {
 type GlobalSettings = {
     ScenariosSettings: ScenarioSetting[]
     TargetScenarios: string[]
-    ReportFileName: string option
+    ReportFileName: string
     ReportFormats: string[]
 }
 

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -101,8 +101,8 @@ let buildScenarios (context: NBomberRunnerContext) =
     let targetScenarios = tryGetTargetScenarios(context)
 
     if not(Array.isEmpty registeredScenarios) then
-        let scnNames = registeredScenarios |> Array.map(fun x -> x.ScenarioName)
-        Log.Information("registered scenarios: {0}", scnNames |> concatWithCommaAndQuotes)
+        let scnNames = registeredScenarios |> Array.map(fun x -> x.ScenarioName) |> concatWithCommaAndQuotes
+        Log.Information("registered scenarios: {0}", scnNames)
 
     match (scenarioSettings, targetScenarios) with
     | Some settings, Some targetScns -> 

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -14,9 +14,6 @@ open NBomber.Infra.Dependency
 open NBomber.DomainServices.Reporting
 open NBomber.DomainServices.ScenarioRunner
 
-let concatWithCommaAndQuotes (strings: string[]) =
-    strings |> String.concat("', '") |> sprintf "'%s'"
-
 let tryGetScenariosSettings (context: NBomberRunnerContext) = maybe {
     let! config = context.NBomberConfig
     let! globalSettings = config.GlobalSettings
@@ -48,7 +45,7 @@ let updateScenarioWithSettings (scenario: Scenario) (settings: ScenarioSetting) 
                     Duration = settings.Duration }
 
 let filterTargetScenarios (targetScenarios: string[]) (scenarios: Scenario[]) =
-    Log.Information("target scenarios from config: {0}", targetScenarios |> concatWithCommaAndQuotes)
+    Log.Information("target scenarios from config: {0}", targetScenarios |> String.concatWithCommaAndQuotes)
 
     scenarios 
     |> Array.filter(fun x -> targetScenarios |> Array.exists(fun target -> x.ScenarioName = target))
@@ -101,7 +98,7 @@ let buildScenarios (context: NBomberRunnerContext) =
     let targetScenarios = tryGetTargetScenarios(context)
 
     if not(Array.isEmpty registeredScenarios) then
-        let scnNames = registeredScenarios |> Array.map(fun x -> x.ScenarioName) |> concatWithCommaAndQuotes
+        let scnNames = registeredScenarios |> Array.map(fun x -> x.ScenarioName) |> String.concatWithCommaAndQuotes
         Log.Information("registered scenarios: {0}", scnNames)
 
     match (scenarioSettings, targetScenarios) with

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -15,7 +15,7 @@ open NBomber.DomainServices.Reporting
 open NBomber.DomainServices.ScenarioRunner
 
 let concatWithCommaAndQuotes (strings: string[]) =
-        strings |> String.concat("', '") |> sprintf "'%s'"
+    strings |> String.concat("', '") |> sprintf "'%s'"
 
 let tryGetScenariosSettings (context: NBomberRunnerContext) = maybe {
     let! config = context.NBomberConfig

--- a/src/NBomber/DomainServices/Reporting/TxtReport.fs
+++ b/src/NBomber/DomainServices/Reporting/TxtReport.fs
@@ -27,7 +27,7 @@ let private printStepsTable (steps: StepStats[]) =
         stepTable.AddRow("- name", s.StepName) |> ignore
         stepTable.AddRow("- request count", String.Format("all = {0} | OK = {1} | failed = {2}", s.ReqeustCount, s.OkCount, s.FailCount)) |> ignore
         stepTable.AddRow("- response time", String.Format("RPS = {0} | min = {1} | mean = {2} | max = {3} ", p.RPS, p.Min, p.Mean, p.Max)) |> ignore
-        stepTable.AddRow("- response time percentile", String.Format("50% = {0} | 75% = {1} | 95% = {2} | StdDev= {3}", p.Percent50, p.Percent75, p.Percent95, p.StdDev)) |> ignore
+        stepTable.AddRow("- response time percentile", String.Format("50% = {0} | 75% = {1} | 95% = {2} | StdDev = {3}", p.Percent50, p.Percent75, p.Percent95, p.StdDev)) |> ignore
         
         if dataInfoAvailable then
             stepTable.AddRow("- data transfer", String.Format("min = {0}Kb | mean = {1}Kb | max = {2}Kb | all = {3}MB", s.DataTransfer.MinKb, s.DataTransfer.MeanKb, s.DataTransfer.MaxKb, s.DataTransfer.AllMB)) |> ignore

--- a/src/NBomber/DomainServices/Validation.fs
+++ b/src/NBomber/DomainServices/Validation.fs
@@ -33,7 +33,7 @@ let concurrentCopiesGreaterThenOne (globalSettings: GlobalSettings) =
                                                 |> Error
 
 let isReportFileNameNotEmpty (globalSettings: GlobalSettings) =
-    if String.IsNullOrEmpty(globalSettings.ReportFileName) then
+    if String.IsNullOrEmpty globalSettings.ReportFileName then
         Error("Report File Name can not be empty string.")
     else
         Ok(globalSettings)

--- a/src/NBomber/DomainServices/Validation.fs
+++ b/src/NBomber/DomainServices/Validation.fs
@@ -33,13 +33,10 @@ let concurrentCopiesGreaterThenOne (globalSettings: GlobalSettings) =
                                                 |> Error
 
 let isReportFileNameNotEmpty (globalSettings: GlobalSettings) =
-    match globalSettings.ReportFileName with
-    | Some reportFileName -> 
-        if String.IsNullOrEmpty(reportFileName) then
-            Error("Report File Name can not be empty string.")
-        else
-            Ok(globalSettings)
-    | None -> Ok(globalSettings)
+    if String.IsNullOrEmpty(globalSettings.ReportFileName) then
+        Error("Report File Name can not be empty string.")
+    else
+        Ok(globalSettings)
 
 let validateReportFormat (reportFormat: string) =
     if String.IsNullOrEmpty(reportFormat) then

--- a/src/NBomber/Extensions.fs
+++ b/src/NBomber/Extensions.fs
@@ -36,5 +36,8 @@ module String =
 
     let replace (oldValue: string, newValue: string) (str: string) =
         str.Replace(oldValue, newValue)
+
+    let concatWithCommaAndQuotes (strings: string[]) =
+        "'" + (strings |> String.concat("', '")) + "'"
         
 

--- a/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
+++ b/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
@@ -9,7 +9,7 @@ open NBomber.Configuration
 open NBomber.DomainServices
 open NBomber.Contracts
 
-let buildConfig (scenarioName: string, settings: ScenarioSetting[], targetScenarios: string[], reportFileName: string option, reportFormats: string[]) =
+let buildConfig (scenarioName: string, settings: ScenarioSetting[], targetScenarios: string[], reportFileName: string, reportFormats: string[]) =
     let scenario = Scenario.create(scenarioName, [])
     let globalSettings = { ScenariosSettings = settings; TargetScenarios = targetScenarios; ReportFileName = reportFileName; ReportFormats = reportFormats }
     let config = { NBomberConfig.GlobalSettings = Some globalSettings }
@@ -23,7 +23,7 @@ let buildSettings (scenarioName: string, warmUpDuration: TimeSpan, duration: Tim
 let ``validateRunnerContext() should return Ok for any args values`` (scenarioName: string, warmUpDuration: TimeSpan, duration: TimeSpan, concurrentCopies: int, reportFileName: string) =
     let settings = buildSettings(scenarioName, warmUpDuration, duration, concurrentCopies)
 
-    let validatedContext = buildConfig(scenarioName, [|settings|], [|scenarioName|], Some(reportFileName), [||])
+    let validatedContext = buildConfig(scenarioName, [|settings|], [|scenarioName|], reportFileName, [||])
                             |> Validation.validateRunnerContext
     
     if duration < TimeSpan.FromSeconds(1.0) then
@@ -45,7 +45,7 @@ let ``validateRunnerContext() should return Ok for any args values`` (scenarioNa
 let ``validateRunnerContext() should fail when report formats are unknown`` (reportFormats: string[]) =    
     let settings = buildSettings("scenario_name", TimeSpan.FromSeconds(10.0), TimeSpan.FromSeconds(10.0), 10)
 
-    let validatedContext = buildConfig("scenario_name", [|settings|], [|"scenario_name"|], None, reportFormats)
+    let validatedContext = buildConfig("scenario_name", [|settings|], [|"scenario_name"|], "report_file_name", reportFormats)
                             |> Validation.validateRunnerContext
 
     let atLeastOneReportFormatUnknown = reportFormats |> Array.map(Validation.validateReportFormat) |> Array.exists(fun x -> x.IsNone)
@@ -60,7 +60,7 @@ let ``validateRunnerContext() should fail when report formats are unknown`` (rep
 [<Property>]
 let ``validateRunnerContext() should fail when target scenrio name is not declared`` (scenarioName: string) =    
     let targetScenarios = [|scenarioName + "new_name"|]
-    let errorMessage = buildConfig(scenarioName, Array.empty, targetScenarios, None, [||])
+    let errorMessage = buildConfig(scenarioName, Array.empty, targetScenarios, "report_file_name", [||])
                         |> Validation.validateRunnerContext
                         |> Result.getError
     


### PR DESCRIPTION
removing option from report file name;
adding more output to the console;
fixing issue with sorting when gettnig the longest scenario

Example output:
[12:07:20 INF] NBomber started a new session: '04.01.2019_12.07.95_f93443a7'
[12:07:21 INF] registered scenarios: 'test_youtube', 'test_mongo'
[12:07:21 INF] target scenarios from config: 'test_youtube', 'test_mongo'
[12:07:21 INF] initializing scenario: 'test_youtube'
[12:07:21 INF] initializing scenario: 'test_mongo'
[12:07:21 INF] warming up scenario: 'test_youtube'
100.00%                                                                                                                                                                              00:00:05████████████████████████████████████████████████████████
[12:07:27 INF] warming up scenario: 'test_mongo'
100.00%                                                                                                                                                                              00:00:05████████████████████████████████████████████████████████████
[12:07:33 INF] starting bombing...
[12:07:33 INF] waiting time: duration '00:00:30' of the longest scenario 'test_mongo'...
100.00%                                                                                                                                                                              00:00:30████████████████████████████████████████████████████████████
[12:08:03 INF] reports saved in folder: 'C:\Projects\NBomber\examples\FSharp\FSharp.Examples\reports',

[12:08:03 INF] Scenario: test_youtube, execution time: 00:00:05