### PR TITLE
Adding printing validation error when running tests

### DIFF
--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -180,6 +180,6 @@ let run (dep: Dependency, context: NBomberRunnerContext) =
                 TestFrameworkRunner.showResults(assertResults)        
     
     | Error ex ->
-        let errorMessage = ex |> toString
+        let errorMessage = toString(ex)
         if dep.ApplicationType = ApplicationType.Test then TestFrameworkRunner.showValidationErrors(errorMessage)
         else Log.Error(errorMessage)

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -179,4 +179,7 @@ let run (dep: Dependency, context: NBomberRunnerContext) =
             if dep.ApplicationType = ApplicationType.Test then
                 TestFrameworkRunner.showResults(assertResults)        
     
-    | Error ex -> ex |> toString |> Log.Error
+    | Error ex ->
+        let errorMessage = ex |> toString
+        if dep.ApplicationType = ApplicationType.Test then TestFrameworkRunner.showValidationErrors(errorMessage)
+        else Log.Error(errorMessage)


### PR DESCRIPTION
Added `printErrors ` function as a private function to reuse in existing `showResults ` and in new `showValidationErrors `

