### PR TITLE
adding assertions to html report

### DIFF
--- a/src/NBomber/Domain/Errors.fs
+++ b/src/NBomber/Domain/Errors.fs
@@ -69,20 +69,6 @@ let toString (error) =
 
     | EmptyStepName scenarioNames->
         scenarioNames |> String.concatWithCommaAndQuotes |> sprintf "Step names are empty in scenarios: %s. Step names should not be empty within scenario."
-
-let toHtmlString (error) =
-    match error with
-    | AssertNotFound (_,assertion) -> 
-        match assertion with
-        | Step s ->
-            let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
-            sprintf "<li class=\"list-group-item list-group-item-danger\">Assertion <strong>'%s'</strong> is not found for step <strong>'%s'</strong></li>" labelStr s.StepName
-    | AssertionError (_,assertion,_) ->
-        match assertion with
-        | Step s ->
-            let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
-            sprintf "<li class=\"list-group-item list-group-item-danger\">Failed assertion <strong>'%s'</strong> for step <strong>'%s'</strong></li>" labelStr s.StepName
-    | _ -> String.Empty
  
 let getErrorsString (results: Result<_,DomainError>[]) =
     results 

--- a/src/NBomber/Domain/Errors.fs
+++ b/src/NBomber/Domain/Errors.fs
@@ -76,12 +76,12 @@ let toHtmlString (error) =
         match assertion with
         | Step s ->
             let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
-            sprintf "<li class='list-group-item list-group-item-danger'>Assertion <strong>'%s'</strong> is not found for step <strong>'%s'</strong></li>" labelStr s.StepName
+            sprintf "<li class=\"list-group-item list-group-item-danger\">Assertion <strong>'%s'</strong> is not found for step <strong>'%s'</strong></li>" labelStr s.StepName
     | AssertionError (_,assertion,_) ->
         match assertion with
         | Step s ->
             let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
-            sprintf "<li class='list-group-item list-group-item-danger'>Failed assertion <strong>'%s'</strong> for step <strong>'%s'</strong></li>" labelStr s.StepName
+            sprintf "<li class=\"list-group-item list-group-item-danger\">Failed assertion <strong>'%s'</strong> for step <strong>'%s'</strong></li>" labelStr s.StepName
     | _ -> String.Empty
  
 let getErrorsString (results: Result<_,DomainError>[]) =

--- a/src/NBomber/Domain/Errors.fs
+++ b/src/NBomber/Domain/Errors.fs
@@ -70,6 +70,20 @@ let toString (error) =
     | EmptyStepName scenarioNames->
         scenarioNames |> String.concatWithCommaAndQuotes |> sprintf "Step names are empty in scenarios: %s. Step names should not be empty within scenario."
 
+let toHtmlString (error) =
+    match error with
+    | AssertNotFound (_,assertion) -> 
+        match assertion with
+        | Step s ->
+            let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
+            sprintf "<li class='list-group-item list-group-item-danger'>Assertion <strong>'%s'</strong> is not found for step <strong>'%s'</strong></li>" labelStr s.StepName
+    | AssertionError (_,assertion,_) ->
+        match assertion with
+        | Step s ->
+            let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
+            sprintf "<li class='list-group-item list-group-item-danger'>Failed assertion <strong>'%s'</strong> for step <strong>'%s'</strong></li>" labelStr s.StepName
+    | _ -> String.Empty
+ 
 let getErrorsString (results: Result<_,DomainError>[]) =
     results 
     |> Array.filter(Result.isError)

--- a/src/NBomber/Domain/Errors.fs
+++ b/src/NBomber/Domain/Errors.fs
@@ -69,7 +69,7 @@ let toString (error) =
 
     | EmptyStepName scenarioNames->
         scenarioNames |> String.concatWithCommaAndQuotes |> sprintf "Step names are empty in scenarios: %s. Step names should not be empty within scenario."
- 
+
 let getErrorsString (results: Result<_,DomainError>[]) =
     results 
     |> Array.filter(Result.isError)

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -175,9 +175,9 @@ let run (dep: Dependency, context: NBomberRunnerContext) =
             let reportFileName = tryGetReportFileName(context) |> Option.defaultValue declaredReportFileName
             let reportFormats = tryGetReportFormats(context) |> Option.defaultValue context.ReportFormats
 
-            let assertErrors = assertResults |> Array.filter(Result.isError) |> Array.map(Result.getError)
+            let failedAsserts = assertResults |> Array.filter(Result.isError) |> Array.map(Result.getError)
 
-            Report.build(dep, globalStats, assertErrors)
+            Report.build(dep, globalStats, failedAsserts)
             |> Report.save(dep, "./", reportFileName, reportFormats)
                         
             cleanScenarios(scnRunners)

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -175,7 +175,9 @@ let run (dep: Dependency, context: NBomberRunnerContext) =
             let reportFileName = tryGetReportFileName(context) |> Option.defaultValue declaredReportFileName
             let reportFormats = tryGetReportFormats(context) |> Option.defaultValue context.ReportFormats
 
-            Report.build(dep, globalStats, assertResults)
+            let assertErrors = assertResults |> Array.filter(Result.isError) |> Array.map(Result.getError)
+
+            Report.build(dep, globalStats, assertErrors)
             |> Report.save(dep, "./", reportFileName, reportFormats)
                         
             cleanScenarios(scnRunners)

--- a/src/NBomber/DomainServices/Reporting/HtmlReport.fs
+++ b/src/NBomber/DomainServices/Reporting/HtmlReport.fs
@@ -47,7 +47,6 @@ module NumberReqChart =
         { Html = html; Js = js }
 
 module StatisticsTable =    
-    open NBomber.Domain.Errors
 
     let print (assets: Assets, scnStats: ScenarioStats[], assertResults: Result<Assertion,DomainError>[]) =     
 
@@ -75,7 +74,7 @@ module StatisticsTable =
                 |> Array.filter(Result.isError)
                 |> Array.map(Result.getError)
                 |> Array.map(toHtmlString)
-                |> String.concat(String.Empty) 
+                |> String.concat(String.Empty)
 
             let row = scnStats.StepsStats
                       |> Array.map(fun step -> printStepRow(step))

--- a/src/NBomber/DomainServices/Reporting/HtmlReport.fs
+++ b/src/NBomber/DomainServices/Reporting/HtmlReport.fs
@@ -66,15 +66,20 @@ module StatisticsTable =
                                         ["-"; "-"; "-"; "-"]
 
             dataTransferBlock |> List.append data |> HtmlBuilder.toTableRow
-
-        let printScenarioTable (scnStats) =  
-
+        
+        let printAssertions (assertResults) =
             let assertionsStr =
                 assertResults
                 |> Array.filter(Result.isError)
                 |> Array.map(Result.getError)
                 |> Array.map(toHtmlString)
                 |> String.concat(String.Empty)
+
+            if String.IsNullOrEmpty(assertionsStr) then String.Empty
+            else sprintf "<ul class=\"list-group\">%s</ul><br/>" assertionsStr
+
+        let printScenarioTable (scnStats) =  
+            let assertionsStr = printAssertions(assertResults)
 
             let row = scnStats.StepsStats
                       |> Array.map(fun step -> printStepRow(step))

--- a/src/NBomber/DomainServices/Reporting/HtmlReport.fs
+++ b/src/NBomber/DomainServices/Reporting/HtmlReport.fs
@@ -2,7 +2,6 @@
 
 open System
 
-open NBomber.Domain.DomainTypes
 open NBomber.Domain.StatisticsTypes
 open NBomber.Domain.Errors
 open NBomber.Infra
@@ -48,7 +47,7 @@ module NumberReqChart =
 
 module StatisticsTable =    
 
-    let print (assets: Assets, scnStats: ScenarioStats[], assertResults: Result<Assertion,DomainError>[]) =     
+    let print (assets: Assets, scnStats: ScenarioStats[], assertErrors: DomainError[]) =     
 
         let printStepRow (step: StepStats) =            
             let data = [step.StepName; step.ReqeustCount.ToString();
@@ -66,20 +65,9 @@ module StatisticsTable =
                                         ["-"; "-"; "-"; "-"]
 
             dataTransferBlock |> List.append data |> HtmlBuilder.toTableRow
-        
-        let printAssertions (assertResults) =
-            let assertionsStr =
-                assertResults
-                |> Array.filter(Result.isError)
-                |> Array.map(Result.getError)
-                |> Array.map(toHtmlString)
-                |> String.concat(String.Empty)
-
-            if String.IsNullOrEmpty(assertionsStr) then String.Empty
-            else sprintf "<ul class=\"list-group\">%s</ul><br/>" assertionsStr
 
         let printScenarioTable (scnStats) =  
-            let assertionsStr = printAssertions(assertResults)
+            let assertionsStr = HtmlBuilder.toListGroup(assertErrors)
 
             let row = scnStats.StepsStats
                       |> Array.map(fun step -> printStepRow(step))
@@ -103,7 +91,7 @@ module ScenarioView =
     let createViewId (index: int) = String.Format("scenario-view-{0}", index)
     let createName (index: int) = String.Format("Scenario {0}", index)
 
-    let print (assets: Assets, index: int, scnStats: ScenarioStats, assertResults: Result<Assertion,DomainError>[]) = 
+    let print (assets: Assets, index: int, scnStats: ScenarioStats, assertErrors: DomainError[]) = 
 
         let viewId = createViewId(index)
         let label = createName(index)
@@ -111,7 +99,7 @@ module ScenarioView =
         let indicatorsChart = IndicatorsChart.print(assets, viewId, label, scnStats.LatencyCount, scnStats.FailCount)
         let numberReqChart = NumberReqChart.print(assets, viewId, scnStats.OkCount, scnStats.FailCount)
 
-        let statisticsTableHtml = StatisticsTable.print(assets, [|scnStats|], assertResults)
+        let statisticsTableHtml = StatisticsTable.print(assets, [|scnStats|], assertErrors)
         
         let js = indicatorsChart.Js + numberReqChart.Js
         let html = assets.ScenarioViewHtml
@@ -124,13 +112,13 @@ module ScenarioView =
 
 module GlobalView =  
 
-    let print (assets: Assets, stats: GlobalStats, assertResults: Result<Assertion,DomainError>[]) =        
+    let print (assets: Assets, stats: GlobalStats, assertErrors: DomainError[]) =        
         
         let viewId = "global-view"
         let indicatorsChart = IndicatorsChart.print(assets, viewId, "All Scenarios", stats.LatencyCount, stats.FailCount)
         let numberReqChart = NumberReqChart.print(assets, viewId, stats.OkCount, stats.FailCount)
         
-        let statisticsTableHtml = StatisticsTable.print(assets, stats.AllScenariosStats, assertResults)
+        let statisticsTableHtml = StatisticsTable.print(assets, stats.AllScenariosStats, assertErrors)
 
         let js = indicatorsChart.Js + numberReqChart.Js
         let html = assets.GlobalViewHtml
@@ -165,13 +153,13 @@ module EnvView =
 
 module ContentView =
 
-    let print (dep: Dependency, stats: GlobalStats, assertResults: Result<Assertion,DomainError>[]) =        
+    let print (dep: Dependency, stats: GlobalStats, assertErrors: DomainError[]) =        
         let envHtml = EnvView.print(dep.Assets, dep.MachineInfo)
-        let globalView = GlobalView.print(dep.Assets, stats, assertResults)
+        let globalView = GlobalView.print(dep.Assets, stats, assertErrors)
         
         let scnViews =
             if stats.AllScenariosStats.Length > 1 then
-                let scnViews = stats.AllScenariosStats |> Array.mapi(fun i x -> ScenarioView.print(dep.Assets, i+1,x, assertResults))
+                let scnViews = stats.AllScenariosStats |> Array.mapi(fun i x -> ScenarioView.print(dep.Assets, i+1,x, assertErrors))
                 let scnHtml = scnViews |> Array.map(fun x -> x.Html) |> String.concat(String.Empty)
                 let scnJs = scnViews |> Array.map(fun x -> x.Js) |> String.concat(String.Empty)
                 { Html = scnHtml; Js = scnJs }
@@ -213,10 +201,10 @@ module SideBar =
         let sideBarItems = envItem + globalItem + scnItems
         assets.SidebarHtml.Replace("%sideBar_items%", sideBarItems)
 
-let print (dep: Dependency, stats: GlobalStats, assertResults: Result<Assertion,DomainError>[]) =
+let print (dep: Dependency, stats: GlobalStats, assertErrors: DomainError[]) =
     let sideBar = SideBar.print(dep.Assets, stats)
 
-    let contentView = ContentView.print(dep, stats, assertResults)
+    let contentView = ContentView.print(dep, stats, assertErrors)
 
     dep.Assets.IndexHtml
     |> String.replace("%sidebar%", sideBar)

--- a/src/NBomber/DomainServices/Reporting/HtmlReport.fs
+++ b/src/NBomber/DomainServices/Reporting/HtmlReport.fs
@@ -2,7 +2,9 @@
 
 open System
 
+open NBomber.Domain.DomainTypes
 open NBomber.Domain.StatisticsTypes
+open NBomber.Domain.Errors
 open NBomber.Infra
 open NBomber.Infra.ResourceManager
 open NBomber.Infra.Dependency
@@ -45,10 +47,11 @@ module NumberReqChart =
         { Html = html; Js = js }
 
 module StatisticsTable =    
+    open NBomber.Domain.Errors
 
-    let print (assets: Assets, scnStats: ScenarioStats[]) =     
+    let print (assets: Assets, scnStats: ScenarioStats[], assertResults: Result<Assertion,DomainError>[]) =     
 
-        let printStepRow (step) =            
+        let printStepRow (step: StepStats) =            
             let data = [step.StepName; step.ReqeustCount.ToString();
                         step.OkCount.ToString(); step.FailCount.ToString();
                         step.RPS.ToString(); step.Min.ToString(); step.Mean.ToString(); step.Max.ToString();
@@ -67,6 +70,13 @@ module StatisticsTable =
 
         let printScenarioTable (scnStats) =  
 
+            let assertionsStr =
+                assertResults
+                |> Array.filter(Result.isError)
+                |> Array.map(Result.getError)
+                |> Array.map(toHtmlString)
+                |> String.concat(String.Empty) 
+
             let row = scnStats.StepsStats
                       |> Array.map(fun step -> printStepRow(step))
                       |> String.concat(String.Empty)                      
@@ -76,6 +86,7 @@ module StatisticsTable =
             let tableTitle = String.Format("Statistics for Scenario: <b>{0}</b>, Duration: <b>{1}</b>, RPS: <b>{2}</b>, Concurrent Copies: <b>{3}</b>", scnStats.ScenarioName, scnStats.Duration, scnStats.RPS, scnStats.ConcurrentCopies)
             
             assets.StatisticsTableHtml
+            |> String.replace("%assertions%", assertionsStr)
             |> String.replace("%table_title%", tableTitle)
             |> String.replace("%table_body%", "<tr>" + rowStr)
 
@@ -88,7 +99,7 @@ module ScenarioView =
     let createViewId (index: int) = String.Format("scenario-view-{0}", index)
     let createName (index: int) = String.Format("Scenario {0}", index)
 
-    let print (assets: Assets, index: int, scnStats: ScenarioStats) = 
+    let print (assets: Assets, index: int, scnStats: ScenarioStats, assertResults: Result<Assertion,DomainError>[]) = 
 
         let viewId = createViewId(index)
         let label = createName(index)
@@ -96,7 +107,7 @@ module ScenarioView =
         let indicatorsChart = IndicatorsChart.print(assets, viewId, label, scnStats.LatencyCount, scnStats.FailCount)
         let numberReqChart = NumberReqChart.print(assets, viewId, scnStats.OkCount, scnStats.FailCount)
 
-        let statisticsTableHtml = StatisticsTable.print(assets, [|scnStats|])
+        let statisticsTableHtml = StatisticsTable.print(assets, [|scnStats|], assertResults)
         
         let js = indicatorsChart.Js + numberReqChart.Js
         let html = assets.ScenarioViewHtml
@@ -109,13 +120,13 @@ module ScenarioView =
 
 module GlobalView =  
 
-    let print (assets: Assets, stats: GlobalStats) =        
+    let print (assets: Assets, stats: GlobalStats, assertResults: Result<Assertion,DomainError>[]) =        
         
         let viewId = "global-view"
         let indicatorsChart = IndicatorsChart.print(assets, viewId, "All Scenarios", stats.LatencyCount, stats.FailCount)
         let numberReqChart = NumberReqChart.print(assets, viewId, stats.OkCount, stats.FailCount)
         
-        let statisticsTableHtml = StatisticsTable.print(assets, stats.AllScenariosStats)
+        let statisticsTableHtml = StatisticsTable.print(assets, stats.AllScenariosStats, assertResults)
 
         let js = indicatorsChart.Js + numberReqChart.Js
         let html = assets.GlobalViewHtml
@@ -150,13 +161,13 @@ module EnvView =
 
 module ContentView =
 
-    let print (dep: Dependency, stats: GlobalStats) =        
+    let print (dep: Dependency, stats: GlobalStats, assertResults: Result<Assertion,DomainError>[]) =        
         let envHtml = EnvView.print(dep.Assets, dep.MachineInfo)
-        let globalView = GlobalView.print(dep.Assets, stats)
+        let globalView = GlobalView.print(dep.Assets, stats, assertResults)
         
         let scnViews =
             if stats.AllScenariosStats.Length > 1 then
-                let scnViews = stats.AllScenariosStats |> Array.mapi(fun i x -> ScenarioView.print(dep.Assets, i+1,x))
+                let scnViews = stats.AllScenariosStats |> Array.mapi(fun i x -> ScenarioView.print(dep.Assets, i+1,x, assertResults))
                 let scnHtml = scnViews |> Array.map(fun x -> x.Html) |> String.concat(String.Empty)
                 let scnJs = scnViews |> Array.map(fun x -> x.Js) |> String.concat(String.Empty)
                 { Html = scnHtml; Js = scnJs }
@@ -198,10 +209,10 @@ module SideBar =
         let sideBarItems = envItem + globalItem + scnItems
         assets.SidebarHtml.Replace("%sideBar_items%", sideBarItems)
 
-let print (dep: Dependency, stats: GlobalStats) =
+let print (dep: Dependency, stats: GlobalStats, assertResults: Result<Assertion,DomainError>[]) =
     let sideBar = SideBar.print(dep.Assets, stats)
 
-    let contentView = ContentView.print(dep, stats)
+    let contentView = ContentView.print(dep, stats, assertResults)
 
     dep.Assets.IndexHtml
     |> String.replace("%sidebar%", sideBar)

--- a/src/NBomber/DomainServices/Reporting/Report.fs
+++ b/src/NBomber/DomainServices/Reporting/Report.fs
@@ -18,9 +18,9 @@ type ReportResult = {
     CsvReport: string   
 }
 
-let build (dep: Dependency, stats: GlobalStats, assertErrors: DomainError[]) =
+let build (dep: Dependency, stats: GlobalStats, failedAsserts: DomainError[]) =
     { TxtReport = TxtReport.print(stats)
-      HtmlReport = HtmlReport.print(dep, stats, assertErrors)
+      HtmlReport = HtmlReport.print(dep, stats, failedAsserts)
       CsvReport = CsvReport.print(stats) }
 
 let save (dep: Dependency, outPutDir: string, reportFileName: string, reportFormats: ReportFormat[]) (report: ReportResult) =

--- a/src/NBomber/DomainServices/Reporting/Report.fs
+++ b/src/NBomber/DomainServices/Reporting/Report.fs
@@ -21,7 +21,7 @@ type ReportResult = {
 let build (dep: Dependency, stats: GlobalStats,
            assertResults: Result<Assertion,DomainError>[]) =
     { TxtReport = TxtReport.print(stats)
-      HtmlReport = HtmlReport.print(dep, stats)
+      HtmlReport = HtmlReport.print(dep, stats, assertResults)
       CsvReport = CsvReport.print(stats) }
 
 let save (dep: Dependency, outPutDir: string, reportFileName: string, reportFormats: ReportFormat[]) (report: ReportResult) =

--- a/src/NBomber/DomainServices/Reporting/Report.fs
+++ b/src/NBomber/DomainServices/Reporting/Report.fs
@@ -18,10 +18,9 @@ type ReportResult = {
     CsvReport: string   
 }
 
-let build (dep: Dependency, stats: GlobalStats,
-           assertResults: Result<Assertion,DomainError>[]) =
+let build (dep: Dependency, stats: GlobalStats, assertErrors: DomainError[]) =
     { TxtReport = TxtReport.print(stats)
-      HtmlReport = HtmlReport.print(dep, stats, assertResults)
+      HtmlReport = HtmlReport.print(dep, stats, assertErrors)
       CsvReport = CsvReport.print(stats) }
 
 let save (dep: Dependency, outPutDir: string, reportFileName: string, reportFormats: ReportFormat[]) (report: ReportResult) =

--- a/src/NBomber/Infra/HtmlBuilder.fs
+++ b/src/NBomber/Infra/HtmlBuilder.fs
@@ -3,6 +3,9 @@
 open System
 open System.Xml.Linq
 
+open NBomber.Domain.Errors
+open NBomber.Domain.DomainTypes
+
 let toTableCell (rowspan: int) (rawData: 'T) =
     String.Format("""<td rowspan="{0}">{1}</td>""", rowspan, rawData)
 
@@ -25,3 +28,23 @@ let toPrettyHtml (html: string) =
             .ToString()
             |> String.replace("<root>", "<!DOCTYPE HTML>")
             |> String.replace("</root>", String.Empty)
+
+let toListGroupItem (assertError) =
+    match assertError with
+    | AssertNotFound (_,assertion) -> 
+        match assertion with
+        | Step s ->
+            let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
+            sprintf "<li class=\"list-group-item list-group-item-danger\">Assertion <strong>'%s'</strong> is not found for step <strong>'%s'</strong></li>" labelStr s.StepName
+    | AssertionError (_,assertion,_) ->
+        match assertion with
+        | Step s ->
+            let labelStr = if s.Label.IsSome then s.Label.Value else String.Empty
+            sprintf "<li class=\"list-group-item list-group-item-danger\">Failed assertion <strong>'%s'</strong> for step <strong>'%s'</strong></li>" labelStr s.StepName
+    | _ -> String.Empty
+
+let toListGroup (assertErrors) =
+    let assertionsStr = assertErrors |> Array.map(toListGroupItem) |> String.concat(String.Empty)
+
+    if String.IsNullOrEmpty(assertionsStr) then String.Empty
+    else sprintf "<ul class=\"list-group\">%s</ul><br/>" assertionsStr

--- a/src/NBomber/Infra/HtmlBuilder.fs
+++ b/src/NBomber/Infra/HtmlBuilder.fs
@@ -29,8 +29,8 @@ let toPrettyHtml (html: string) =
             |> String.replace("<root>", "<!DOCTYPE HTML>")
             |> String.replace("</root>", String.Empty)
 
-let toListGroupItem (assertError) =
-    match assertError with
+let toListGroupItem (failedAssert) =
+    match failedAssert with
     | AssertNotFound (_,assertion) -> 
         match assertion with
         | Step s ->
@@ -43,8 +43,8 @@ let toListGroupItem (assertError) =
             sprintf "<li class=\"list-group-item list-group-item-danger\">Failed assertion <strong>'%s'</strong> for step <strong>'%s'</strong></li>" labelStr s.StepName
     | _ -> String.Empty
 
-let toListGroup (assertErrors) =
-    let assertionsStr = assertErrors |> Array.map(toListGroupItem) |> String.concat(String.Empty)
+let toListGroup (failedAsserts) =
+    let assertionsStr = failedAsserts |> Array.map(toListGroupItem) |> String.concat(String.Empty)
 
     if String.IsNullOrEmpty(assertionsStr) then String.Empty
     else sprintf "<ul class=\"list-group\">%s</ul><br/>" assertionsStr

--- a/src/NBomber/assets/html/statistics_table.html
+++ b/src/NBomber/assets/html/statistics_table.html
@@ -1,6 +1,10 @@
 ﻿<div class="card custom scenario" style="margin-bottom: 20px">
     <div class="card-header custom">%table_title%</div>
     <div class="card-body">
+        <ul class="list-group">
+            %assertions%
+        </ul>
+        <br />
         <table class="table table-hover table-sm table-responsive-lg">
             <thead>
                 <tr>

--- a/src/NBomber/assets/html/statistics_table.html
+++ b/src/NBomber/assets/html/statistics_table.html
@@ -1,10 +1,7 @@
 ﻿<div class="card custom scenario" style="margin-bottom: 20px">
     <div class="card-header custom">%table_title%</div>
     <div class="card-body">
-        <ul class="list-group">
-            %assertions%
-        </ul>
-        <br />
+        %assertions%
         <table class="table table-hover table-sm table-responsive-lg">
             <thead>
                 <tr>


### PR DESCRIPTION
Added assertions to HTML report view

IMPORTANT:
`let printStepRow (step: StepStats) = `

I had to include `StepStats `as a type of `step`; because if I drop the type definition - compilation error occurs.

Preview:

![image](https://user-images.githubusercontent.com/4246666/51180826-7019bb00-18c1-11e9-91d1-f157f787f818.png)
