### PR TITLE
fix unescaped slash in path

### DIFF
--- a/tests/NBomber.IntegrationTests/Configuration/ParseJson.fs
+++ b/tests/NBomber.IntegrationTests/Configuration/ParseJson.fs
@@ -7,7 +7,7 @@ open NBomber.Configuration
 
 [<Fact>]
 let ``NBomberConfig.parse() should read json file successfully`` () =
-    "Configuration\config.json"
+    "Configuration/config.json"
     |> File.ReadAllText
     |> NBomberConfig.parse
     |> Option.isSome


### PR DESCRIPTION
didn't work on mac