### PR TITLE
Fix wrong stats

### DIFF
--- a/src/NBomber/Domain/Statistics.fs
+++ b/src/NBomber/Domain/Statistics.fs
@@ -142,8 +142,8 @@ module StepStats =
         |> Array.map(fun (name, stats) -> 
             let dataTransfer = stats |> Array.map(fun x -> x.DataTransfer) |> StepResults.mergeTraffic
             let okLatencies = stats |> Array.collect(fun x -> x.OkLatencies)
-            let histogram = buildHistogram(okLatencies)            
-            let failCount = stepsStats |> Array.sumBy(fun x -> x.FailCount)
+            let histogram = buildHistogram(okLatencies)
+            let failCount = stats |> Array.sumBy(fun x -> x.FailCount)
 
             { StepName = name
               OkLatencies = okLatencies

--- a/tests/NBomber.IntegrationTests/Step/Pull.fs
+++ b/tests/NBomber.IntegrationTests/Step/Pull.fs
@@ -38,6 +38,7 @@ let ``Ok and Fail should be properly count`` () =
     Scenario.create "count test" [okStep; failStep]
     |> Scenario.withConcurrentCopies 1
     |> Scenario.withAssertions assertions
+    |> Scenario.withWarmUpDuration(TimeSpan.FromSeconds 0.0)
     |> Scenario.withDuration(TimeSpan.FromSeconds 1.0)
     |> NBomberRunner.registerScenario
     |> NBomberRunner.runTest

--- a/tests/NBomber.IntegrationTests/Step/Pull.fs
+++ b/tests/NBomber.IntegrationTests/Step/Pull.fs
@@ -12,21 +12,27 @@ open NBomber.FSharp
 [<Fact>]
 let ``Ok and Fail should be properly count`` () =       
     
+    let mutable okCnt = 0
+    let mutable failCnt = 0
+    
     let okStep = Step.create("ok step", ConnectionPool.none, fun context -> task {
         do! Task.Delay(TimeSpan.FromSeconds(0.1))
+        okCnt <- okCnt + 1
         return Response.Ok()
     })
 
     let failStep = Step.create("fail step", ConnectionPool.none, fun context -> task {
         do! Task.Delay(TimeSpan.FromSeconds(0.1))
+        failCnt <- failCnt + 1
         return Response.Fail()
     })
 
     let assertions = [
-       Assertion.forStep("ok step", fun stats -> stats.OkCount >= 4)
-       Assertion.forStep("ok step", fun stats -> stats.OkCount < 6)
-       Assertion.forStep("fail step", fun stats -> stats.FailCount >= 4)
-       Assertion.forStep("fail step", fun stats -> stats.OkCount < 6)
+       Assertion.forStep("ok step", fun stats -> [okCnt-1..okCnt] |> Seq.contains stats.OkCount)
+       Assertion.forStep("ok step", fun stats -> stats.FailCount = 0)
+
+       Assertion.forStep("fail step", fun stats -> stats.OkCount = 0)
+       Assertion.forStep("fail step", fun stats -> [failCnt-1..failCnt] |> Seq.contains stats.FailCount)
     ]
     
     Scenario.create "pull test" [okStep; failStep]


### PR DESCRIPTION
This fixes the issue with a failure on one step being mapped accumulated and mapped to all steps in scenario.

* Add more specific tests to reproduce problem
* Fix failure count to only count pr step