### PR TITLE
Save execution logs to file

### DIFF
--- a/examples/FSharp/FSharp.Examples/Program.fs
+++ b/examples/FSharp/FSharp.Examples/Program.fs
@@ -11,7 +11,7 @@ let main argv =
     |> Scenario.withDuration(TimeSpan.FromSeconds(5.0))        
     |> NBomberRunner.registerScenario
     // |> NBomberRunner.registerScenarios
-    // |> NBomberRunner.loadConfig "config.json"
+    |> NBomberRunner.loadConfig "config.json"
     // |> NBomberRunner.withReportFileName "custom_report_name"
     // |> NBomberRunner.withReportFormats [ReportFormat.Txt; ReportFormat.Html; ReportFormat.Csv]
     |> NBomberRunner.runInConsole

--- a/examples/FSharp/FSharp.Examples/config.json
+++ b/examples/FSharp/FSharp.Examples/config.json
@@ -1,4 +1,7 @@
 ﻿{
+  "LogSetting": {
+    "LogToFile": "nbomber_execution.log"
+  },
   "GlobalSettings": {
     "ScenariosSettings": [
       {

--- a/src/NBomber/Configuration.fs
+++ b/src/NBomber/Configuration.fs
@@ -1,12 +1,18 @@
 ﻿namespace NBomber.Configuration
 
 open System
+open Serilog.Events
 
 type ReportFormat = 
     | Txt = 0
     | Html = 1
     | Csv = 2
     | Md = 3
+
+type LogSetting = {
+    LogToFile: string
+    MinimumLevel: LogEventLevel option
+}
 
 type ScenarioSetting = {
     ScenarioName: string
@@ -16,6 +22,7 @@ type ScenarioSetting = {
 }
 
 type GlobalSettings = {
+    LogSetting: LogSetting option
     ScenariosSettings: ScenarioSetting list
     TargetScenarios: string list
     ReportFileName: string option
@@ -46,6 +53,7 @@ type ClusterSettings =
 type NBomberConfig = {
     GlobalSettings: GlobalSettings option    
     ClusterSettings: ClusterSettings option
+    LogSetting: LogSetting option
 }
 
 module internal NBomberConfig =    

--- a/src/NBomber/DomainServices/NBomberContext.fs
+++ b/src/NBomber/DomainServices/NBomberContext.fs
@@ -41,3 +41,8 @@ let tryGetReportFormats (context: NBomberContext) = maybe {
     let! settings = config.GlobalSettings
     return! settings.ReportFormats    
 }
+
+let tryGetLogSettings (context: NBomberContext) = maybe {
+    let! config = context.NBomberConfig
+    return! config.LogSetting
+}

--- a/src/NBomber/DomainServices/NBomberRunner.fs
+++ b/src/NBomber/DomainServices/NBomberRunner.fs
@@ -115,7 +115,7 @@ let showAsserts (dep: Dependency) (result: ExecutionResult) =
 
 let run (dep: Dependency) (context: NBomberContext) =
     asyncResult {
-        Dependency.Logger.initLogger(dep.ApplicationType)    
+        Dependency.Logger.initLogger(dep.ApplicationType, context |> NBomberContext.tryGetLogSettings)    
         Log.Information("NBomber started a new session: '{0}'", dep.SessionId)
 
         let! ctx = Validation.validateContext(context)

--- a/src/NBomber/NBomber.fsproj
+++ b/src/NBomber/NBomber.fsproj
@@ -67,6 +67,7 @@
     <PackageReference Include="HdrHistogram" Version="2.5.0" />    
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="ShellProgressBar" Version="4.2.0" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
     <PackageReference Include="ConsoleTables" Version="2.3.0" />

--- a/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
+++ b/tests/NBomber.IntegrationTests/Configuration/ValidateContext.fs
@@ -16,6 +16,7 @@ let globalSettings = {
     TargetScenarios = ["1"]
     ReportFileName = None
     ReportFormats = None 
+    LogSetting = None
 }
 
 let scenarioSettings = { 

--- a/tests/NBomber.IntegrationTests/Logger/FileLogger.fs
+++ b/tests/NBomber.IntegrationTests/Logger/FileLogger.fs
@@ -1,0 +1,33 @@
+﻿module FileLogger
+
+open System.IO
+open Xunit
+
+open NBomber.Configuration
+open NBomber.Infra
+open NBomber.Infra.Dependency
+open Serilog.Events
+open Serilog
+
+[<Fact>]
+let ``With file name in LogSetting.LogToFile Logger should save to file`` () =
+
+    let tempFilePath = Path.GetTempFileName()
+
+    let logSetting = {
+        MinimumLevel = Some LogEventLevel.Information
+        LogToFile = tempFilePath
+    }
+
+    let information = "Information message for test"
+    let verbose = "Verbose message for test"
+
+    Dependency.Logger.initLogger(ApplicationType.Console, Some logSetting)
+
+    Log.Logger.Information(information)
+    Log.Logger.Verbose(verbose)
+    Log.CloseAndFlush()
+
+    let content = File.ReadAllText(tempFilePath)
+    Assert.Contains(information, content)
+    Assert.DoesNotContain(verbose, content)

--- a/tests/NBomber.IntegrationTests/NBomber.IntegrationTests.fsproj
+++ b/tests/NBomber.IntegrationTests/NBomber.IntegrationTests.fsproj
@@ -6,6 +6,7 @@
     <ProjectReference Include="..\..\src\NBomber\NBomber.fsproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Logger\FileLogger.fs" />
     <Compile Include="Extensions.fs" />
     <Content Include="Configuration\config.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Save execution logs to file if `LogSetting` is passed via json configuration file