### PR TITLE
bumb dependencies

### DIFF
--- a/examples/CSharp/HelloWorld/HelloWorldExample.cs
+++ b/examples/CSharp/HelloWorld/HelloWorldExample.cs
@@ -21,6 +21,7 @@ namespace CSharp.HelloWorld
 
             var step2 = Step.Create("step_2", async context =>
             {
+                await Task.Yield();
                 var value = context.GetPreviousStepResponse<int>(); // 42
                 return Response.Ok();
             });

--- a/examples/CSharp/HelloWorld/HelloWorldExample.cs
+++ b/examples/CSharp/HelloWorld/HelloWorldExample.cs
@@ -21,7 +21,6 @@ namespace CSharp.HelloWorld
 
             var step2 = Step.Create("step_2", async context =>
             {
-                await Task.Yield();
                 var value = context.GetPreviousStepResponse<int>(); // 42
                 return Response.Ok();
             });

--- a/src/NBomber/NBomber.fsproj
+++ b/src/NBomber/NBomber.fsproj
@@ -53,20 +53,20 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="15.0.0" />
+    <PackageReference Include="CsvHelper" Version="15.0.5" />
     <PackageReference Include="FSharp.Control.Reactive" Version="4.2.0" />
-    <PackageReference Include="FSharp.Json" Version="0.3.7" />
-    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="1.2.6" />
+    <PackageReference Include="FSharp.Json" Version="0.4.0" />
+    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="1.4.3" />
     <PackageReference Include="HdrHistogram" Version="2.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageReference Include="ShellProgressBar" Version="4.3.0" />
-    <PackageReference Include="ConsoleTables" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="ShellProgressBar" Version="5.0.0" />
+    <PackageReference Include="ConsoleTables" Version="2.4.2" />
     <PackageReference Include="Streams" Version="0.6.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`dotnet outdated -u` all the stuff

`FSharp.Control.Reactive` is hold back, because it requires `FSharp.Core >= 4.7.2`
