### PR TITLE
bump deps

### DIFF
--- a/examples/FSharp/DataFeed/DataFeedTest.fs
+++ b/examples/FSharp/DataFeed/DataFeedTest.fs
@@ -2,7 +2,7 @@ module FSharp.DataFeed.DataFeedTest
 
 open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber
 open NBomber.Contracts

--- a/examples/FSharp/FSharp.fsproj
+++ b/examples/FSharp/FSharp.fsproj
@@ -58,4 +58,8 @@
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\NBomber\NBomber.fsproj" />
+    </ItemGroup>
+
 </Project>

--- a/examples/FSharp/HelloWorld/CustomSettingsExample.fs
+++ b/examples/FSharp/HelloWorld/CustomSettingsExample.fs
@@ -3,7 +3,7 @@ module FSharp.HelloWorld.CustomSettingsExample
 open System.Threading.Tasks
 
 open Microsoft.Extensions.Configuration
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.FSharp

--- a/examples/FSharp/HelloWorld/HelloWorldExample.fs
+++ b/examples/FSharp/HelloWorld/HelloWorldExample.fs
@@ -2,7 +2,7 @@ module FSharp.HelloWorld.HelloWorldExample
 
 open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.FSharp

--- a/examples/FSharp/HttpTests/AdvancedHttpTest.fs
+++ b/examples/FSharp/HttpTests/AdvancedHttpTest.fs
@@ -1,6 +1,6 @@
 module FSharp.HttpTests.AdvancedHttpTest
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open Newtonsoft.Json
 
 open NBomber

--- a/examples/FSharp/HttpTests/AdvancedHttpWithConfig.fs
+++ b/examples/FSharp/HttpTests/AdvancedHttpWithConfig.fs
@@ -1,6 +1,6 @@
 module FSharp.HttpTests.AdvancedHttpWithConfig
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open Newtonsoft.Json
 
 open NBomber

--- a/examples/FSharp/Logging/ElasticSearchLogging.fs
+++ b/examples/FSharp/Logging/ElasticSearchLogging.fs
@@ -1,7 +1,7 @@
 module FSharp.Logging.ElasticSearchLogging
 
 open System.Threading.Tasks
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.FSharp

--- a/examples/FSharp/MongoDb/MongoDbTest.fs
+++ b/examples/FSharp/MongoDb/MongoDbTest.fs
@@ -4,7 +4,7 @@ open System
 open System.Threading
 open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open MongoDB.Bson
 open MongoDB.Bson.Serialization.Attributes
 

--- a/examples/FSharp/RealtimeReporting/InfluxDbReporting.fs
+++ b/examples/FSharp/RealtimeReporting/InfluxDbReporting.fs
@@ -1,7 +1,7 @@
 module FSharp.RealtimeReporting.InfluxDbReporting
 
 open System.Threading.Tasks
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.FSharp

--- a/examples/FSharp/XUnit/XUnitTest.fs
+++ b/examples/FSharp/XUnit/XUnitTest.fs
@@ -2,7 +2,7 @@ module FSharp.DataFeed.XUnitTest
 
 open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open Xunit
 open Swensen.Unquote
 

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 
 open Serilog
 open CommandLine
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open FsToolkit.ErrorHandling
 open Microsoft.Extensions.Configuration
 

--- a/src/NBomber/Domain/Concurrency/ScenarioActor.fs
+++ b/src/NBomber/Domain/Concurrency/ScenarioActor.fs
@@ -6,7 +6,7 @@ open System.Threading.Tasks
 
 open Nessos.Streams
 open Serilog
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.Domain

--- a/src/NBomber/Domain/Concurrency/Scheduler/ConstantActorScheduler.fs
+++ b/src/NBomber/Domain/Concurrency/Scheduler/ConstantActorScheduler.fs
@@ -3,7 +3,7 @@ module internal NBomber.Domain.Concurrency.Scheduler.ConstantActorScheduler
 open System.Collections.Generic
 open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Extensions.InternalExtensions
 open NBomber.Domain.Concurrency

--- a/src/NBomber/Domain/ConnectionPool.fs
+++ b/src/NBomber/Domain/ConnectionPool.fs
@@ -6,7 +6,7 @@ open System.Threading.Tasks
 
 open FsToolkit.ErrorHandling
 open FSharp.Control.Reactive
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber
 open NBomber.Extensions.InternalExtensions

--- a/src/NBomber/Domain/Step.fs
+++ b/src/NBomber/Domain/Step.fs
@@ -8,7 +8,7 @@ open System.Threading.Tasks
 
 open Nessos.Streams
 open Serilog
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber
 open NBomber.Extensions.InternalExtensions

--- a/src/NBomber/DomainServices/TestHost/TestHost.fs
+++ b/src/NBomber/DomainServices/TestHost/TestHost.fs
@@ -7,7 +7,7 @@ open System.Diagnostics
 open System.Runtime.InteropServices
 
 open Nessos.Streams
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open FsToolkit.ErrorHandling
 
 open NBomber.Contracts

--- a/src/NBomber/NBomber.fsproj
+++ b/src/NBomber/NBomber.fsproj
@@ -55,14 +55,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="15.0.5" />
-    <PackageReference Include="FSharp.Control.Reactive" Version="4.2.0" />
+    <PackageReference Include="CsvHelper" Version="16.2.0" />
+    <PackageReference Include="FSharp.Control.Reactive" Version="4.4.2" />
     <PackageReference Include="FSharp.Json" Version="0.4.0" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
-    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="1.4.3" />
+    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="2.0.0" />
     <PackageReference Include="HdrHistogram" Version="2.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
@@ -73,7 +73,7 @@
     <PackageReference Include="Streams" Version="0.6.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\HtmlReport\assets\js\index.js" />

--- a/tests/NBomber.IntegrationTests/CliArgsTests.fs
+++ b/tests/NBomber.IntegrationTests/CliArgsTests.fs
@@ -3,7 +3,7 @@ module Tests.CliArgs
 open System
 open System.IO
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open Swensen.Unquote
 open Xunit
 

--- a/tests/NBomber.IntegrationTests/Concurrency/ScenarioSchedulerTests.fs
+++ b/tests/NBomber.IntegrationTests/Concurrency/ScenarioSchedulerTests.fs
@@ -6,7 +6,7 @@ open Xunit
 open FsCheck
 open FsCheck.Xunit
 open Swensen.Unquote
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open FsToolkit.ErrorHandling
 
 open NBomber.Contracts

--- a/tests/NBomber.IntegrationTests/ConnectionPoolTests.fs
+++ b/tests/NBomber.IntegrationTests/ConnectionPoolTests.fs
@@ -7,7 +7,7 @@ open Xunit
 open FsCheck
 open FsCheck.Xunit
 open Swensen.Unquote
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.FSharp
@@ -30,7 +30,8 @@ let ``should distribute connection with one to one mapping if connectionPool.Cou
         if context.CorrelationId.CopyNumber <> context.Connection then
             return Response.Fail "distribution is not following one to one mapping"
 
-        else return Response.Ok()
+        else
+            return Response.Ok()
     })
 
     let scenario =
@@ -96,7 +97,7 @@ let ``should distribute connection using modulo if connectionPool.Count < loadSi
     | Error error -> failwith error
 
 [<Fact>]
-let ``should be shared btw steps as singlton instance``() =
+let ``should be shared btw steps as singleton instance``() =
 
     let poolCount = 100
 

--- a/tests/NBomber.IntegrationTests/LoggingTests.fs
+++ b/tests/NBomber.IntegrationTests/LoggingTests.fs
@@ -10,7 +10,7 @@ open Xunit
 open FsCheck
 open FsCheck.Xunit
 open Swensen.Unquote
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.FSharp

--- a/tests/NBomber.IntegrationTests/NBomber.IntegrationTests.fsproj
+++ b/tests/NBomber.IntegrationTests/NBomber.IntegrationTests.fsproj
@@ -56,6 +56,6 @@
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/tests/NBomber.IntegrationTests/Plugins/PluginTests.fs
+++ b/tests/NBomber.IntegrationTests/Plugins/PluginTests.fs
@@ -4,7 +4,7 @@ open System
 open System.Data
 open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open Swensen.Unquote
 open Xunit
 

--- a/tests/NBomber.IntegrationTests/Reporting/ReportingConfigurationTests.fs
+++ b/tests/NBomber.IntegrationTests/Reporting/ReportingConfigurationTests.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 open NBomber.Configuration
 open Xunit
 open Swensen.Unquote
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.Domain

--- a/tests/NBomber.IntegrationTests/Reporting/ReportingSinkTests.fs
+++ b/tests/NBomber.IntegrationTests/Reporting/ReportingSinkTests.fs
@@ -5,7 +5,7 @@ open System.Threading.Tasks
 
 open Xunit
 open Swensen.Unquote
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.Domain

--- a/tests/NBomber.IntegrationTests/ScenarioTests.fs
+++ b/tests/NBomber.IntegrationTests/ScenarioTests.fs
@@ -7,7 +7,7 @@ open Xunit
 open FsCheck
 open FsCheck.Xunit
 open Swensen.Unquote
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 open Microsoft.Extensions.Configuration
 
 open NBomber.Extensions

--- a/tests/NBomber.IntegrationTests/StatisticsTests.fs
+++ b/tests/NBomber.IntegrationTests/StatisticsTests.fs
@@ -7,7 +7,7 @@ open Xunit
 open FsCheck.Xunit
 open Swensen.Unquote
 open Nessos.Streams
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.Domain

--- a/tests/NBomber.IntegrationTests/StepTests.fs
+++ b/tests/NBomber.IntegrationTests/StepTests.fs
@@ -5,7 +5,7 @@ open System.Threading.Tasks
 
 open Xunit
 open Swensen.Unquote
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks.NonAffine
 
 open NBomber.Contracts
 open NBomber.Errors


### PR DESCRIPTION
- updated all packages - mostly minor versions
- increased FSharp.Core minimal version to 4.7.2 because of downgrading in some packages.
- FsToolkit.ErrorHandling.TaskResult 2.0 uses Ply now instead of `TaskBuilder.fs`. 
   - changed all using namespaces accordingly in the code base. 
   - this is a transitive dependency. So the client code using NBomber should now either also fix namespaces or add explicit reference to the task builder package.

#### Some notes

This test fails now: 
`Tests.ConnectionPool.should distribute connection with one to one mapping if connectionPool.Count = loadSimulation copiesCount`
I think it was also the case by my previous attempt to switch to Ply. Still don't know what's wrong though

To get rid of compiler errors for now in the feature branch, added a project reference to override a NBomber package reference in the `examples/FSharp` project. Not sure what benefits has a nuget in this case.
