### PR TITLE
add fault-tolerant for plugin stats

### DIFF
--- a/src/NBomber/Configuration/Constants.fs
+++ b/src/NBomber/Configuration/Constants.fs
@@ -51,6 +51,7 @@ let MinSendStatsInterval = TimeSpan.FromSeconds 5.0
 let DefaultSendStatsInterval = TimeSpan.FromSeconds 10.0
 let SchedulerNotificationTickInterval = TimeSpan.FromSeconds 1.0
 let StepTimeout = TimeSpan.FromSeconds 1.0
+let GetPluginStatsTimeout = TimeSpan.FromSeconds 0.5
 let TimeoutStatusCode = -100
 let StepExceptionStatusCode = -101
 

--- a/src/NBomber/Configuration/Constants.fs
+++ b/src/NBomber/Configuration/Constants.fs
@@ -51,7 +51,7 @@ let MinSendStatsInterval = TimeSpan.FromSeconds 5.0
 let DefaultSendStatsInterval = TimeSpan.FromSeconds 10.0
 let SchedulerNotificationTickInterval = TimeSpan.FromSeconds 1.0
 let StepTimeout = TimeSpan.FromSeconds 1.0
-let GetPluginStatsTimeout = TimeSpan.FromSeconds 0.5
+let GetPluginStatsTimeout = TimeSpan.FromSeconds 5.0
 let TimeoutStatusCode = -100
 let StepExceptionStatusCode = -101
 

--- a/src/NBomber/DomainServices/TestHost/TestHostReporting.fs
+++ b/src/NBomber/DomainServices/TestHost/TestHostReporting.fs
@@ -39,21 +39,22 @@ let saveFinalStats (dep: IGlobalDependency) (stats: NodeStats[]) = task {
 }
 
 let getPluginStats (dep: IGlobalDependency) (operation: OperationType) = task {
-        try
-            let pluginStatusesTask =
-                dep.WorkerPlugins
-                |> List.map(fun plugin -> plugin.GetStats operation)
-                |> Task.WhenAll
-            let! finishedTask = Task.WhenAny(pluginStatusesTask, Task.Delay(Constants.GetPluginStatsTimeout))
-            if finishedTask.Id = pluginStatusesTask.Id then return pluginStatusesTask.Result
-            else
-                 dep.Logger.Error("Getting plugin stats failed with the timeout error")
-                 return Array.empty
-        with
-        | ex ->
-            dep.Logger.Error(ex, "Getting plugin stats failed with the following error")
+    try
+        let pluginStatusesTask =
+            dep.WorkerPlugins
+            |> List.map(fun plugin -> plugin.GetStats operation)
+            |> Task.WhenAll
+            
+        let! finishedTask = Task.WhenAny(pluginStatusesTask, Task.Delay(Constants.GetPluginStatsTimeout))
+        if finishedTask.Id = pluginStatusesTask.Id then return pluginStatusesTask.Result
+        else
+            dep.Logger.Error("Getting plugin stats failed with the timeout error.")
             return Array.empty
-    }
+    with
+    | ex ->
+        dep.Logger.Error(ex, "Getting plugin stats failed with the following error.")
+        return Array.empty
+}
 
 let getScenarioStats (schedulers: ScenarioScheduler list) (working: bool) (duration: TimeSpan) =
     schedulers

--- a/tests/NBomber.IntegrationTests/NBomber.IntegrationTests.fsproj
+++ b/tests/NBomber.IntegrationTests/NBomber.IntegrationTests.fsproj
@@ -50,6 +50,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="Serilog.Sinks.InMemory" Version="0.2.0" />
+        <PackageReference Include="Serilog.Sinks.InMemory.Assertions" Version="0.8.0" />
         <PackageReference Include="Unquote" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/NBomber.IntegrationTests/Reporting/ReportingSinkTests.fs
+++ b/tests/NBomber.IntegrationTests/Reporting/ReportingSinkTests.fs
@@ -5,8 +5,9 @@ open System.Threading.Tasks
 
 open Serilog
 open Serilog.Sinks.InMemory
-open Xunit
+open Serilog.Sinks.InMemory.Assertions
 open Swensen.Unquote
+open Xunit
 open FSharp.Control.Tasks.NonAffine
 
 open NBomber
@@ -15,7 +16,6 @@ open NBomber.Contracts.Stats
 open NBomber.Domain
 open NBomber.FSharp
 open NBomber.Extensions.InternalExtensions
-open Serilog.Sinks.InMemory.Assertions
 
 //todo: test that multiply sink will be invoked correctly
 //todo: test that stop timer stops sending metrics in case when stopping is still executing


### PR DESCRIPTION
closes #364
- add fault-tolerant for plugin stats
- add timeout for getPluginStats
- add logging on errors