### PR TITLE
#376 Print received latency

### DIFF
--- a/src/NBomber/Plugins/PingPlugin.fs
+++ b/src/NBomber/Plugins/PingPlugin.fs
@@ -89,13 +89,12 @@ module internal PingPluginHintsAnalyzer =
     /// (hostName * result)[]
     let analyze (pingResults: (string * PingReply)[]) =
 
-        let printHint (hostName) =
-            sprintf "Physical latency to host: '%s' is bigger than 2ms which is not appropriate for load testing. You should run your test in an environment with very small latency." hostName
+        let printHint (hostName, result:PingReply) =
+            $"Physical latency to host: '%s{hostName}' is '%d{result.RoundtripTime}'.  This is bigger than 2ms which is not appropriate for load testing. You should run your test in an environment with very small latency."
 
         pingResults
         |> Seq.filter(fun (_,result) -> result.RoundtripTime > 2L)
-        |> Seq.map fst
-        |> Seq.map printHint
+        |> Seq.map(printHint)
         |> Seq.toArray
 
 type PingPlugin(pluginConfig: PingPluginConfig) =

--- a/src/NBomber/Plugins/PingPlugin.fs
+++ b/src/NBomber/Plugins/PingPlugin.fs
@@ -89,12 +89,12 @@ module internal PingPluginHintsAnalyzer =
     /// (hostName * result)[]
     let analyze (pingResults: (string * PingReply)[]) =
 
-        let printHint (hostName, result:PingReply) =
+        let printHint (hostName, result: PingReply) =
             $"Physical latency to host: '%s{hostName}' is '%d{result.RoundtripTime}'.  This is bigger than 2ms which is not appropriate for load testing. You should run your test in an environment with very small latency."
 
         pingResults
         |> Seq.filter(fun (_,result) -> result.RoundtripTime > 2L)
-        |> Seq.map(printHint)
+        |> Seq.map printHint
         |> Seq.toArray
 
 type PingPlugin(pluginConfig: PingPluginConfig) =


### PR DESCRIPTION
The current PingPluginHintsAnalyzer prints error message like this:

"Physical latency to host: 'nbomber.com' is bigger than 2ms which is not appropriate for load testing. You should run your test in an environment with very small latency."

But it doesn't say anything about the real latency that it received.
The real latency contains in PingReply.RoundtripTime